### PR TITLE
Fix a bug when using torch.jit.trace to convert model when torch version <1.5

### DIFF
--- a/resnest/torch/splat.py
+++ b/resnest/torch/splat.py
@@ -54,7 +54,10 @@ class SplAtConv2d(Module):
 
         batch, rchannel = x.shape[:2]
         if self.radix > 1:
-            splited = torch.split(x, rchannel//self.radix, dim=1)
+            if torch.__version__ < '1.5':
+                splited = torch.split(x, int(rchannel//self.radix), dim=1)
+            else:
+                splited = torch.split(x, rchannel//self.radix, dim=1)
             gap = sum(splited) 
         else:
             gap = x
@@ -69,7 +72,10 @@ class SplAtConv2d(Module):
         atten = self.rsoftmax(atten).view(batch, -1, 1, 1)
 
         if self.radix > 1:
-            attens = torch.split(atten, rchannel//self.radix, dim=1)
+            if torch.__version__ < '1.5':
+                attens = torch.split(atten, int(rchannel//self.radix), dim=1)
+            else:
+                attens = torch.split(atten, rchannel//self.radix, dim=1)
             out = sum([att*split for (att, split) in zip(attens, splited)])
         else:
             out = atten * x


### PR DESCRIPTION
test code is 
```python
import torch
from resnest.torch.resnest import resnest50


def save(model, input):
    m = torch.jit.trace(model, input)
    m.save('jit.pt')


if __name__ == '__main__':
    x = torch.rand(1, 3, 640, 640)
    model = resnest50(False)
    model.eval()
    save(model,x)

    y = model(x)

    model1 = torch.jit.load('jit.pt')
    y1 = model1(x)
    assert (y1==y).all()
    assert (y1-y).max()==0
```
bug info is
```bash
Traceback (most recent call last):
  File "D:/code/ResNeSt/t.py", line 17, in <module>
    save(model,x)
  File "D:/code/ResNeSt/t.py", line 9, in save
    m = torch.jit.trace(model, input)
  File "D:\Anaconda3\lib\site-packages\torch\jit\__init__.py", line 858, in trace
    check_tolerance, _force_outplace, _module_class)
  File "D:\Anaconda3\lib\site-packages\torch\jit\__init__.py", line 997, in trace_module
    module._c._create_method_from_trace(method_name, func, example_inputs, var_lookup_fn, _force_outplace)
  File "D:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 539, in __call__
    result = self._slow_forward(*input, **kwargs)
  File "D:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 525, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "D:\code\ResNeSt\resnest\torch\resnet.py", line 293, in forward
    x = self.layer1(x)
  File "D:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 539, in __call__
    result = self._slow_forward(*input, **kwargs)
  File "D:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 525, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "D:\Anaconda3\lib\site-packages\torch\nn\modules\container.py", line 92, in forward
    input = module(input)
  File "D:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 539, in __call__
    result = self._slow_forward(*input, **kwargs)
  File "D:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 525, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "D:\code\ResNeSt\resnest\torch\resnet.py", line 106, in forward
    out = self.conv2(out)
  File "D:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 539, in __call__
    result = self._slow_forward(*input, **kwargs)
  File "D:\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 525, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "D:\code\ResNeSt\resnest\torch\splat.py", line 57, in forward
    splited = torch.split(x, rchannel//self.radix, dim=1)
  File "D:\Anaconda3\lib\site-packages\torch\functional.py", line 77, in split
    return tensor.split(split_size_or_sections, dim)
  File "D:\Anaconda3\lib\site-packages\torch\tensor.py", line 329, in split
    return super(Tensor, self).split_with_sizes(split_size, dim)
TypeError: split_with_sizes(): argument 'split_sizes' (position 1) must be tuple of ints, not Tensor

Process finished with exit code 1

```