### PR TITLE
Add JAX ResNeSt to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install resnest --pre
 | ResNeSt-200 | 320       | 83.84   | 83.88 |
 | ResNeSt-269 | 416       | 84.54   | 84.53 |
 
-- **3rd party implementations** are available: [Tensorflow](https://github.com/QiaoranC/tf_ResNeSt_RegNet_model), [Caffe](https://github.com/NetEase-GameAI/ResNeSt-caffe).
+- **3rd party implementations** are available: [Tensorflow](https://github.com/QiaoranC/tf_ResNeSt_RegNet_model), [Caffe](https://github.com/NetEase-GameAI/ResNeSt-caffe), [JAX](https://github.com/n2cholas/jax-resnet/).
 
 - Extra ablation study models are available in [link](./ablation.md)
 


### PR DESCRIPTION
I've implemented ResNeSt in Flax, and ported the PyTorch checkpoints for ResNeSt [50-Fast, 50, 101, 200, 269] (50-fast refers to `resnest50_fast_2s1x64d`) [here](https://github.com/n2cholas/jax-resnet). I've verified the ports/checkpoints match the PyTorch implementations with the same cropping scheme used in this repo.